### PR TITLE
fix: database migrations on L10

### DIFF
--- a/src/CassandraServiceProvider.php
+++ b/src/CassandraServiceProvider.php
@@ -28,7 +28,7 @@ class CassandraServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->singleton('migration.repository', function ($app) {
+        $this->app->extend('migration.repository', function ($repository, $app) {
             $table = $app['config']['database.migrations'];
 
             return new DatabaseMigrationRepository($app['db'], $table);

--- a/src/Repository/DatabaseMigrationRepository.php
+++ b/src/Repository/DatabaseMigrationRepository.php
@@ -63,7 +63,7 @@ class DatabaseMigrationRepository extends BaseDatabaseMigrationRepository
             $table->uuid('id');
             $table->string('migration');
             $table->integer('batch');
-            $table->primary('id');
+            $table->primary(['id', 'batch']);
         });
     }
 


### PR DESCRIPTION
## Fixes

- Adding right ScyllaDB Migration Repository binding into L10 container 