### PR TITLE
fix(model): cast to carbon with valid method

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -71,11 +71,11 @@ abstract class Model extends BaseModel
     }
 
     /**
-     * //TODO: Dusan HELPPPPPPPPP
+     * Create a new Scylla Timestamp with the current time
      */
     public function freshTimestamp()
     {
-        return new Timestamp();
+        return new Timestamp(time(), 0);
     }
 
     /**
@@ -97,13 +97,16 @@ abstract class Model extends BaseModel
     }
 
     /**
-     * @inheritdoc
+     * Return a Scylla Timestamp as DateTime object.
+     *
+     * @param  mixed  $value
+     * @return Carbon
      */
     protected function asDateTime($value)
     {
         // Convert UTCDateTime instances.
         if ($value instanceof Timestamp || $value instanceof Date) {
-            return Carbon::instance($value->toDateTime());
+            return Carbon::createFromTimestamp($value->time());
         }
 
         return parent::asDateTime($value);

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -73,10 +73,11 @@ abstract class Model extends BaseModel
 
     /**
      * Create a new Scylla Timestamp with the current time
+     * @return Timestamp
      */
     public function freshTimestamp()
     {
-        return new Timestamp(time(), 0);
+        return new Timestamp(seconds: time(), microseconds: 0);
     }
 
     /**


### PR DESCRIPTION
While I was coding an app with the connector, I got some error from the Driver and had to do a workaround to generate Carbon instances.

IMHO this solution uses less memory since it doesn't need to create a new DateTime object to parse to a new Carbon instance. 